### PR TITLE
Use object-fit 'contain' to fix display of taller flags

### DIFF
--- a/react-ui/src/components/LazyLoadCardImage.jsx
+++ b/react-ui/src/components/LazyLoadCardImage.jsx
@@ -1,25 +1,33 @@
 import CardMedia from '@material-ui/core/CardMedia';
+import { makeStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import LazyLoad from 'react-lazyload';
 
 const MAX_RATIO = 4 / 3;
 
+const useStyles = makeStyles({
+  cardMedia: {
+    objectFit: 'contain',
+  },
+});
+
 function LazyLoadCardImage({
   displayWidth, height, width, image,
 }) {
+  const classes = useStyles();
+
   const actualWidth = Math.min(displayWidth, width);
   const maxHeight = Math.min(actualWidth / MAX_RATIO, Math.ceil((height * actualWidth) / width));
   return (
     <div style={{ maxHeight }}>
       <LazyLoad height={maxHeight} offset={100} resize scroll>
         <CardMedia
+          className={classes.cardMedia}
           component="img"
           image={image}
           style={{
-            height: '100%',
             maxHeight,
             maxWidth: displayWidth,
-            width: '100%',
           }}
         />
       </LazyLoad>


### PR DESCRIPTION
Closes #173 