### PR TITLE
Properly load contest when user has voted on a rejected flag

### DIFF
--- a/server/api/contest.js
+++ b/server/api/contest.js
@@ -341,6 +341,9 @@ exports.get = async ({ params: { id }, username }, res) => {
 
       const entriesObj = keyBy(response.entries, response.entries[0].imgurId ? 'imgurId' : 'id');
       votes.forEach(({ entryId, rating }) => {
+        if (!entriesObj[entryId]) {
+          return;
+        }
         entriesObj[entryId].rating = rating;
       });
       response.entries = Object.values(entriesObj);


### PR DESCRIPTION
In the `jun23` contest, one of the entries was rejected after it had already been voted on. This causes an error trying to load the vote value into an entry that is not retrieved.