### PR TITLE
Only send contest entries when none are pending

### DIFF
--- a/server/api/contest.js
+++ b/server/api/contest.js
@@ -302,10 +302,16 @@ exports.get = async ({ params: { id }, username }, res) => {
          WHERE ce.entry_id = e.id AND ce.contest_id = $1 AND e.submission_status = $2`,
         [id, submissionStatus],
       );
-      const pendingEntries = await queryEntries('*', 'pending');
 
-      if (isFuture(voteStart) || pendingEntries.length) {
-        res.send({ name: response.name, votingWindowOpen: false });
+      const votingNotOpenResponse = { name: response.name, votingWindowOpen: false };
+      if (isFuture(voteStart)) {
+        res.send(votingNotOpenResponse);
+        return;
+      }
+
+      const pendingEntries = await queryEntries('*', 'pending');
+      if (pendingEntries.length) {
+        res.send(votingNotOpenResponse);
         return;
       }
 


### PR DESCRIPTION
The contest voting was starting automatically once the date was reached even if there were still pending entries. This will prevent the voting window from opening until both the voting start time is reached and there are no more pending entries.