### PR TITLE
Add fallback for hall of fame cards with no flair available

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node server",
     "build": "cd react-ui/ && npm install && npm run build",
-    "heroku": "nodemon -L --exec \"heroku local\" --signal SIGTERM",
+    "heroku": "nodemon -L --exec \"heroku local\" --signal SIGTERM -- --port 5000",
     "prepare": "husky install"
   },
   "cacheDirectories": [

--- a/react-ui/src/pages/hallOfFame/HallOfFameCard.jsx
+++ b/react-ui/src/pages/hallOfFame/HallOfFameCard.jsx
@@ -24,10 +24,13 @@ import {
 } from '../../components';
 import flair from '../../images/flair.png';
 
-const useStyles = makeStyles((theme) => {
-  const FLAIR_START_YEAR = 2015;
-  const FLAIR_WIDTH = 25;
+// The first year available in /images/flair.png.
+const FLAIR_START_YEAR = 2015;
+// The last year available in /images/flair.png.
+const FLAIR_END_YEAR = 2022;
+const FLAIR_WIDTH = 25;
 
+const useStyles = makeStyles((theme) => {
   const styles = {
     bestOfYear: {
       '&::after': {
@@ -66,10 +69,24 @@ const useStyles = makeStyles((theme) => {
       transform: 'rotate(180deg)',
     },
   };
-  for (let i = FLAIR_START_YEAR; i <= 2022; i += 1) {
-    const offset = (i - FLAIR_START_YEAR) * FLAIR_WIDTH;
-    styles[`bestOfYear${i}`] = { '&::after': { backgroundPosition: `-${offset}px 0` } };
+
+  const currentYear = getYear(new Date());
+  for (let i = FLAIR_START_YEAR; i <= currentYear; i += 1) {
+    const style = {};
+    if (i <= FLAIR_END_YEAR) {
+      // If the flair is available in images/flair.png, set the horizontal offset.
+      const offset = (i - FLAIR_START_YEAR) * FLAIR_WIDTH;
+      style.backgroundPosition = `-${offset}px 0`;
+    } else {
+      // If the flair is not available, use year text instead.
+      style.background = 'none';
+      style.content = `"${i}"`;
+      style.verticalAlign = 0;
+    }
+
+    styles[`bestOfYear${i}`] = { '&::after': style };
   }
+
   return styles;
 });
 


### PR DESCRIPTION
See previous [commit](https://github.com/heshammourad/vexillology-contests/commit/ea18a08a1c39cc58211497b98e0ada5e5e260295) with solution for when this year's flair wasn't available. This is now a general fix for whenever the flair isn't available. When the flair file is updated, we can update the png file and the `_END_YEAR` const value and it should automatically update.