### PR TITLE
Add sort_order column to contest_categories

### DIFF
--- a/server/db/queries.js
+++ b/server/db/queries.js
@@ -9,7 +9,7 @@ const db = require('.');
 
 exports.getCategories = async (contestId) => {
   const categories = await db.select(
-    'SELECT category FROM contest_categories WHERE contest_id = $1 ORDER BY "order", category',
+    'SELECT category FROM contest_categories WHERE contest_id = $1 ORDER BY sort_order, category',
     [contestId],
   );
   return categories.map(({ category }) => category);

--- a/server/db/queries.js
+++ b/server/db/queries.js
@@ -9,7 +9,7 @@ const db = require('.');
 
 exports.getCategories = async (contestId) => {
   const categories = await db.select(
-    'SELECT category FROM contest_categories WHERE contest_id = $1 ORDER BY category',
+    'SELECT category FROM contest_categories WHERE contest_id = $1 ORDER BY "order", category',
     [contestId],
   );
   return categories.map(({ category }) => category);


### PR DESCRIPTION
With this month's contest being about the Gregorian Calendar months (spoiler alert!), it became necessary to have a sort order other than alphabetical, so I added a new column to the `contest_categories` table, and reference it in the query to fetch categories.

```sql
ALTER TABLE vexillology_contests_staging.contest_categories ADD sort_order int2 NULL;
```

Once again, I want to get this in before the contest starts, so I'll go ahead and merge, but please let me know if you have any comments and I'll address in a follow-up.