### PR TITLE
Wrap setAuthState in try-catch

### DIFF
--- a/react-ui/src/common/useAuthState.jsx
+++ b/react-ui/src/common/useAuthState.jsx
@@ -10,7 +10,12 @@ const useAuth = () => {
   // Temp refactoring, to be replaced by force logout in the future
   const { accessToken, authTokens = {}, refreshToken } = authState;
   if (Object.keys(authTokens).length === 0 && accessToken && refreshToken) {
-    setAuthState({ ...authState, authTokens: { accessToken, refreshToken } });
+    try {
+      setAuthState({ ...authState, authTokens: { accessToken, refreshToken } });
+    } catch (e) {
+      // setAuthState is throwing a null reference error, but still updating,
+      // so wrapping in a try-catch. This should be fixed by replacing this library in #281.
+    }
   }
 
   return [authState, setAuthState];


### PR DESCRIPTION
Yet another use-persisted-state bug. For some reason, there's a null reference exception even though it successfully updates the store. I wrapped it in a try-catch for now, but I can't wait for #281 to be fixed.