### PR TITLE
Fixed initial fetch of settings (issue #321)

### DIFF
--- a/react-ui/src/pages/settings/Settings.jsx
+++ b/react-ui/src/pages/settings/Settings.jsx
@@ -8,10 +8,9 @@ import { useLocation } from 'react-router-dom';
 
 import snackbarTypes from '../../common/snackbarTypes';
 import useSnackbarState from '../../common/useSnackbarState';
-import {
-  CustomSwitch, Header, PageContainer, ProtectedRoute,
-} from '../../components';
+import { CustomSwitch, Header, PageContainer, ProtectedRoute } from '../../components';
 import { putData } from '../../data/api';
+import useSwrAuth from '../../data/useSwrAuth';
 import useSwrMutation from '../../data/useSwrMutation';
 
 const URL = '/settings';
@@ -53,7 +52,9 @@ const useStyles = makeStyles((theme) => {
 });
 
 function Settings() {
-  const { data, isMutating, trigger } = useSwrMutation(URL, putData);
+  const { data } = useSwrAuth(URL);
+  // useSwrMutation defers loading until trigger, but shares chare with useSwr
+  const { isMutating, trigger } = useSwrMutation(URL, putData);
   const { state } = useLocation();
 
   const updateSnackbarState = useSnackbarState();


### PR DESCRIPTION
`useSwrMutation` [does not fetch data until trigger](https://swr.vercel.app/docs/mutation#defer-loading-data-until-needed). However, `useSwrMutation` shares a cache store with `useSwr`, so we can simply use `useSwrAuth`. 