### PR TITLE
Fix multiple instances of logger

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "printWidth": 100,
+  "printWidth": 80,
   "singleQuote": true,
   "trailingComma": "all"
 }

--- a/react-ui/src/components/AccountMenu.jsx
+++ b/react-ui/src/components/AccountMenu.jsx
@@ -53,9 +53,10 @@ function AccountMenu({ color }) {
   const { pathname } = useLocation();
   const classes = useStyles();
 
-  // Prettier and eslint aren't playing well together
-  // eslint-disable-next-line max-len
-  const [{ isLoggedIn, authTokens: { refreshToken } = {}, username }, setAuthState] = useAuthState();
+  const [
+    { isLoggedIn, authTokens: { refreshToken } = {}, username },
+    setAuthState,
+  ] = useAuthState();
   const sendUserToAuthUrl = useRedditLogIn();
 
   const {

--- a/react-ui/src/components/CustomSnackbar.jsx
+++ b/react-ui/src/components/CustomSnackbar.jsx
@@ -12,19 +12,25 @@ import snackbarTypes from '../common/snackbarTypes';
 import useComponentsState from '../common/useComponentsState';
 
 const TYPES = {
-  [snackbarTypes.REVIEW_SUBMISSION_ERROR]: 'Error updating submission. Please try again later.',
+  [snackbarTypes.REVIEW_SUBMISSION_ERROR]:
+    'Error updating submission. Please try again later.',
   [snackbarTypes.REVIEW_SUBMISSION_SUCCESS]: 'Submission updated',
-  [snackbarTypes.SETTINGS_ERROR]: 'Error submitting setting. Please try again later.',
+  [snackbarTypes.SETTINGS_ERROR]:
+    'Error submitting setting. Please try again later.',
   [snackbarTypes.SETTINGS_SUCCESS]: 'Setting saved',
-  [snackbarTypes.SUBMISSION_ERROR]: 'Error submitting entry. Please try again later.',
+  [snackbarTypes.SUBMISSION_ERROR]:
+    'Error submitting entry. Please try again later.',
   [snackbarTypes.SUBMISSION_SUCCESS]: 'Entry submitted successfully!',
-  [snackbarTypes.VOTING_ERROR]: 'Error submitting vote. Please try again later.',
+  [snackbarTypes.VOTING_ERROR]:
+    'Error submitting vote. Please try again later.',
   [snackbarTypes.VOTING_SUCCESS]: 'Vote submitted!',
 };
 
 function CustomSnackbar() {
-  // eslint-disable-next-line max-len
-  const [{ snackbar: { openTimestamp, type } = { snackbar: {} } }, setComponentsState] = useComponentsState();
+  const [
+    { snackbar: { openTimestamp, type } = { snackbar: {} } },
+    setComponentsState,
+  ] = useComponentsState();
   const [isOpen, setOpen] = useState(false);
 
   const resetSnackbar = () => {
@@ -67,7 +73,10 @@ function CustomSnackbar() {
       open={isOpen && !!message}
     >
       {message ? (
-        <Alert onClose={handleClose} severity={type.split('_').pop().toLowerCase()}>
+        <Alert
+          onClose={handleClose}
+          severity={type.split('_').pop().toLowerCase()}
+        >
           {message}
         </Alert>
       ) : null}

--- a/react-ui/src/pages/analyzeVotes/AnalyzeVotes.jsx
+++ b/react-ui/src/pages/analyzeVotes/AnalyzeVotes.jsx
@@ -9,16 +9,10 @@ import { makeStyles } from '@material-ui/core/styles';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
 import PropTypes from 'prop-types';
-import {
-  useEffect, useMemo, useState,
-} from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import {
-  Header,
-  PageContainer,
-  ProtectedRoute,
-} from '../../components';
+import { Header, PageContainer, ProtectedRoute } from '../../components';
 import useContestId from '../../data/useContestId';
 import useSwrContests from '../../data/useSwrContests';
 import useSwrModAnalyze from '../../data/useSwrModAnalyze';
@@ -89,8 +83,10 @@ function AnalyzeVotes() {
   const classes = useStyles();
   const contestId = useContestId();
   const { data: contests } = useSwrContests();
-  // eslint-disable-next-line max-len
-  const contest = useMemo(() => contests.find((c) => c.id === contestId) || contests[0], [contests, contestId]);
+  const contest = useMemo(
+    () => contests.find((c) => c.id === contestId) || contests[0],
+    [contests, contestId],
+  );
   const navigate = useNavigate();
   const {
     data: {
@@ -129,26 +125,36 @@ function AnalyzeVotes() {
   }, [numberOfEntries]);
 
   useEffect(() => {
-    if (!usernames.length) { return; }
+    if (!usernames.length) {
+      return;
+    }
     setUser1((prev) => {
       if (prev) {
-        if (usernames.includes(prev)) { return prev; }
+        if (usernames.includes(prev)) {
+          return prev;
+        }
       }
       return usernames[0];
     });
     setUser2((prev) => {
       if (prev) {
-        if (usernames.includes(prev)) { return prev; }
+        if (usernames.includes(prev)) {
+          return prev;
+        }
       }
       return usernames[usernames.length - 1];
     });
   }, [usernames]);
 
-  const entryPositionLookup = useMemo(() => entryAvg
-    .reduce((acc, curr, i) => ({ ...acc, [curr.entryId]: i }), {}), [entryAvg]);
+  const entryPositionLookup = useMemo(
+    () => entryAvg.reduce((acc, curr, i) => ({ ...acc, [curr.entryId]: i }), {}),
+    [entryAvg],
+  );
 
-  // eslint-disable-next-line max-len
-  const entryUserLookup = useMemo(() => userEntries.reduce((acc, curr) => ({ ...acc, [curr.id]: curr.user }), {}), [userEntries]);
+  const entryUserLookup = useMemo(
+    () => userEntries.reduce((acc, curr) => ({ ...acc, [curr.id]: curr.user }), {}),
+    [userEntries],
+  );
 
   return (
     <>
@@ -179,99 +185,122 @@ function AnalyzeVotes() {
             </Select>
           </Box>
 
-          {
-            !votes.length
-              ? (
-                <Typography
-                  className={classes.sideBySide}
-                >
-                  We don&apos;t have any votes for this contest yet. Please choose another contest.
+          {!votes.length ? (
+            <Typography className={classes.sideBySide}>
+              We don&apos;t have any votes for this contest yet. Please choose
+              another contest.
+            </Typography>
+          ) : (
+            <>
+              <Box className={classes.sideBySide}>
+                <Typography style={{ flexShrink: 0, marginRight: 20 }}>
+                  Min votes:
                 </Typography>
-              )
-              : (
-                <>
-                  <Box className={classes.sideBySide}>
-                    <Typography style={{ flexShrink: 0, marginRight: 20 }}>Min votes:</Typography>
-                    <Slider
-                      value={voteMinimum}
-                      onChange={handleMinimumSlider}
-                      step={1}
-                      min={0}
-                      max={numberOfEntries}
-                    />
-                    <Input
-                      value={voteMinimum}
-                      size="small"
-                      onChange={handleMinimumInput}
-                      onBlur={handleMinimumBlur}
-                      inputProps={{
-                        step: 1,
-                        min: 0,
-                        max: numberOfEntries,
-                        type: 'number',
-                        'aria-labelledby': 'input-slider',
-                      }}
-                      style={{ width: '60px', marginLeft: 20 }}
-                    />
-                  </Box>
+                <Slider
+                  value={voteMinimum}
+                  onChange={handleMinimumSlider}
+                  step={1}
+                  min={0}
+                  max={numberOfEntries}
+                />
+                <Input
+                  value={voteMinimum}
+                  size="small"
+                  onChange={handleMinimumInput}
+                  onBlur={handleMinimumBlur}
+                  inputProps={{
+                    step: 1,
+                    min: 0,
+                    max: numberOfEntries,
+                    type: 'number',
+                    'aria-labelledby': 'input-slider',
+                  }}
+                  style={{ width: '60px', marginLeft: 20 }}
+                />
+              </Box>
 
-                  <UserSelector
-                    title="User: "
-                    noVotes={!userAvg.length}
-                    user={user1}
-                    setUser={setUser1}
-                    usernames={usernames}
+              <UserSelector
+                title="User: "
+                noVotes={!userAvg.length}
+                user={user1}
+                setUser={setUser1}
+                usernames={usernames}
+              />
+
+              <Box className={classes.sideBySide}>
+                <Box>
+                  <DeviationFromMean
+                    {...{
+                      user1,
+                      votes,
+                      userAvg,
+                      entryAvg,
+                      setUser1,
+                      voteMinimum,
+                    }}
                   />
-
-                  <Box className={classes.sideBySide}>
-                    <Box>
-                      <DeviationFromMean {...{
-                        user1, votes, userAvg, entryAvg, setUser1, voteMinimum,
-                      }}
-                      />
-                      <Typography><em>Double-click on an axis to remove the zoom</em></Typography>
-
-                    </Box>
-                    <Box>
-                      <UserVsAverage {...{
-                        user1, votes, entryAvg, entryUserLookup, entryPositionLookup,
-                      }}
-                      />
-                      <Typography><em>Double-click on an axis to remove the zoom</em></Typography>
-
-                    </Box>
-                  </Box>
-
-                  <UserSelector
-                    title="User 2: "
-                    noVotes={!userAvg.length}
-                    user={user2}
-                    setUser={setUser2}
-                    usernames={usernames}
+                  <Typography>
+                    <em>Double-click on an axis to remove the zoom</em>
+                  </Typography>
+                </Box>
+                <Box>
+                  <UserVsAverage
+                    {...{
+                      user1,
+                      votes,
+                      entryAvg,
+                      entryUserLookup,
+                      entryPositionLookup,
+                    }}
                   />
-                  <Box className={classes.sideBySide}>
-                    <Box>
-                      <PearsonsCorrelation {...{
-                        user1, user2, votes, entryPositionLookup, setUser2, voteMinimum,
-                      }}
-                      />
-                      <Typography><em>Double-click on an axis to remove the zoom</em></Typography>
+                  <Typography>
+                    <em>Double-click on an axis to remove the zoom</em>
+                  </Typography>
+                </Box>
+              </Box>
 
-                    </Box>
-                    <Box>
-                      <UserVsUser {...{
-                        user1, votes, entryAvg, entryUserLookup, user2, entryPositionLookup,
-                      }}
-                      />
-                      <Typography><em>Double-click on an axis to remove the zoom</em></Typography>
-                    </Box>
-
-                  </Box>
-                </>
-              )
-}
+              <UserSelector
+                title="User 2: "
+                noVotes={!userAvg.length}
+                user={user2}
+                setUser={setUser2}
+                usernames={usernames}
+              />
+              <Box className={classes.sideBySide}>
+                <Box>
+                  <PearsonsCorrelation
+                    {...{
+                      user1,
+                      user2,
+                      votes,
+                      entryPositionLookup,
+                      setUser2,
+                      voteMinimum,
+                    }}
+                  />
+                  <Typography>
+                    <em>Double-click on an axis to remove the zoom</em>
+                  </Typography>
+                </Box>
+                <Box>
+                  <UserVsUser
+                    {...{
+                      user1,
+                      votes,
+                      entryAvg,
+                      entryUserLookup,
+                      user2,
+                      entryPositionLookup,
+                    }}
+                  />
+                  <Typography>
+                    <em>Double-click on an axis to remove the zoom</em>
+                  </Typography>
+                </Box>
+              </Box>
+            </>
+          )}
         </PageContainer>
-
       </ProtectedRoute>
     </>
   );

--- a/react-ui/src/pages/analyzeVotes/DeviationFromMean.jsx
+++ b/react-ui/src/pages/analyzeVotes/DeviationFromMean.jsx
@@ -1,12 +1,9 @@
-/* eslint-disable max-len */
 /* eslint-disable react/forbid-prop-types */
 import PropTypes, { object } from 'prop-types';
 import { useCallback, useEffect, useMemo } from 'react';
 import Plot from 'react-plotly.js';
 
-import {
-  roundTwoDecimals, createTraces, trimUsername,
-} from './functions';
+import { roundTwoDecimals, createTraces, trimUsername } from './functions';
 import MARKERS from './markers';
 
 const GROUP = { selected: 0, none: 1, few: 2 };
@@ -15,7 +12,12 @@ const GROUP = { selected: 0, none: 1, few: 2 };
  * Determine how unlike the average each user voted
  */
 function DeviationFromMean({
-  user1, votes, userAvg, entryAvg, setUser1, voteMinimum,
+  user1,
+  votes,
+  userAvg,
+  entryAvg,
+  setUser1,
+  voteMinimum,
 }) {
   /**
    * CALCULATE Z SCORE FOR EACH USER
@@ -31,19 +33,32 @@ function DeviationFromMean({
       return acc;
     }, {});
 
-    const averagesByEntryLookup = entryAvg.reduce((acc, curr) => ({ ...acc, [curr.entryId]: curr.average }), {});
+    const averagesByEntryLookup = entryAvg.reduce(
+      (acc, curr) => ({ ...acc, [curr.entryId]: curr.average }),
+      {},
+    );
     // Standard deviation calcution
-    const deviationByEntryLookup = Object.keys(allVotesByEntry).reduce((acc, entryId) => {
-      const differences = allVotesByEntry[entryId].map((rating) => (rating - averagesByEntryLookup[entryId]) ** 2);
-      const sd = Math.sqrt(differences.reduce((a, b) => a + b, 0) / differences.length);
-      return { ...acc, [entryId]: sd };
-    }, {});
+    const deviationByEntryLookup = Object.keys(allVotesByEntry).reduce(
+      (acc, entryId) => {
+        const differences = allVotesByEntry[entryId].map(
+          (rating) => (rating - averagesByEntryLookup[entryId]) ** 2,
+        );
+        const sd = Math.sqrt(
+          differences.reduce((a, b) => a + b, 0) / differences.length,
+        );
+        return { ...acc, [entryId]: sd };
+      },
+      {},
+    );
 
     return votes.reduce((acc, vote) => {
       if (!acc[vote.username]) {
         acc[vote.username] = [];
       }
-      acc[vote.username].push((vote.rating - averagesByEntryLookup[vote.entryId]) / deviationByEntryLookup[vote.entryId]);
+      acc[vote.username].push(
+        (vote.rating - averagesByEntryLookup[vote.entryId])
+          / deviationByEntryLookup[vote.entryId],
+      );
       return acc;
     }, {});
   }, [votes, userAvg, entryAvg]);
@@ -60,13 +75,19 @@ function DeviationFromMean({
       group = GROUP.few;
     }
 
-    const zScore = zScoresByUser[ua.username].reduce((a, b) => a + b, 0) / zScoresByUser[ua.username].length;
+    const zScore = zScoresByUser[ua.username].reduce((a, b) => a + b, 0)
+      / zScoresByUser[ua.username].length;
     return {
       x: ua.average,
       y: zScore,
       id: ua.username,
       group,
-      text: `User: ${trimUsername(ua.username, 20)}<br />Avg: ${roundTwoDecimals(ua.average)}<br />Z-score: ${roundTwoDecimals(zScore)}`,
+      text: `User: ${trimUsername(
+        ua.username,
+        20,
+      )}<br />Avg: ${roundTwoDecimals(
+        ua.average,
+      )}<br />Z-score: ${roundTwoDecimals(zScore)}`,
     };
   });
 
@@ -88,19 +109,28 @@ function DeviationFromMean({
   /**
    * ALLOW KEYED NAVIGATION OF THIS CHART (left-right arrows)
    */
-  const usernamesByAvg = useMemo(() => userAvg.sort((a, b) => a.average - b.average).map((ua) => ua.username), [userAvg]);
+  const usernamesByAvg = useMemo(
+    () => userAvg.sort((a, b) => a.average - b.average).map((ua) => ua.username),
+    [userAvg],
+  );
 
-  const handleKeyUp = useCallback(({ key }) => {
-    if (key === 'ArrowLeft' || key === 'ArrowRight') {
-      setUser1((prev) => {
-        const index = usernamesByAvg.indexOf(prev);
-        if (key === 'ArrowLeft') {
-          return usernamesByAvg[index - 1] || usernamesByAvg[usernamesByAvg.length - 1];
-        }
-        return usernamesByAvg[index + 1] || usernamesByAvg[0];
-      });
-    }
-  }, [usernamesByAvg]);
+  const handleKeyUp = useCallback(
+    ({ key }) => {
+      if (key === 'ArrowLeft' || key === 'ArrowRight') {
+        setUser1((prev) => {
+          const index = usernamesByAvg.indexOf(prev);
+          if (key === 'ArrowLeft') {
+            return (
+              usernamesByAvg[index - 1]
+              || usernamesByAvg[usernamesByAvg.length - 1]
+            );
+          }
+          return usernamesByAvg[index + 1] || usernamesByAvg[0];
+        });
+      }
+    },
+    [usernamesByAvg],
+  );
 
   useEffect(() => {
     window.addEventListener('keyup', handleKeyUp);

--- a/react-ui/src/pages/analyzeVotes/PearsonsCorrelation.jsx
+++ b/react-ui/src/pages/analyzeVotes/PearsonsCorrelation.jsx
@@ -1,12 +1,9 @@
-/* eslint-disable max-len */
 /* eslint-disable react/forbid-prop-types */
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useMemo } from 'react';
 import Plot from 'react-plotly.js';
 
-import {
-  roundTwoDecimals, createTraces, trimUsername,
-} from './functions';
+import { roundTwoDecimals, createTraces, trimUsername } from './functions';
 import MARKERS from './markers';
 
 const GROUP = { selected: 0, none: 1, few: 2 };
@@ -15,7 +12,12 @@ const GROUP = { selected: 0, none: 1, few: 2 };
  * Determine similarity between selected user and all other users
  */
 function PearsonsCorrelation({
-  user1, user2, votes, entryPositionLookup, setUser2, voteMinimum,
+  user1,
+  user2,
+  votes,
+  entryPositionLookup,
+  setUser2,
+  voteMinimum,
 }) {
   /**
    * CALCULATE PEARSONS
@@ -23,7 +25,9 @@ function PearsonsCorrelation({
    * covariance(x, y) / (sd_x * sd_y)
    */
   const pearsons = useMemo(() => {
-    if (!user1) { return []; }
+    if (!user1) {
+      return [];
+    }
 
     const numberOfEntries = Object.keys(entryPositionLookup).length;
     const allVotesByUser = votes.reduce((acc, vote) => {
@@ -36,36 +40,50 @@ function PearsonsCorrelation({
 
     const userVotes = allVotesByUser[user1];
     // User did not vote
-    if (!userVotes) { return []; }
+    if (!userVotes) {
+      return [];
+    }
 
     const validPearsons = [];
 
-    Object.keys(allVotesByUser).filter((u) => u !== user1).forEach((u) => {
-      const otherUser = allVotesByUser[u];
-      let sum1 = 0; let sum2 = 0; let sum1Sq = 0; let sum2Sq = 0; let sumProduct = 0;
-      let n = 0;
-      let numVotes = 0;
-      otherUser.forEach((vote, index) => {
-        const userVote = userVotes[index];
-        if (vote > -1) {
-          numVotes += 1;
-          if (userVote > -1) {
-            sum1 += vote;
-            sum2 += userVote;
-            sum1Sq += vote * vote;
-            sum2Sq += userVote * userVote;
-            sumProduct += vote * userVote;
-            n += 1;
+    Object.keys(allVotesByUser)
+      .filter((u) => u !== user1)
+      .forEach((u) => {
+        const otherUser = allVotesByUser[u];
+        let sum1 = 0;
+        let sum2 = 0;
+        let sum1Sq = 0;
+        let sum2Sq = 0;
+        let sumProduct = 0;
+        let n = 0;
+        let numVotes = 0;
+        otherUser.forEach((vote, index) => {
+          const userVote = userVotes[index];
+          if (vote > -1) {
+            numVotes += 1;
+            if (userVote > -1) {
+              sum1 += vote;
+              sum2 += userVote;
+              sum1Sq += vote * vote;
+              sum2Sq += userVote * userVote;
+              sumProduct += vote * userVote;
+              n += 1;
+            }
           }
+        });
+        const num = sumProduct - (sum1 * sum2) / n;
+        const den = Math.sqrt(
+          (sum1Sq - (sum1 * sum1) / n) * (sum2Sq - (sum2 * sum2) / n),
+        );
+
+        if (n !== 0 && den !== 0) {
+          validPearsons.push({
+            username: u,
+            correlation: num / den,
+            group: numVotes < voteMinimum ? GROUP.few : undefined,
+          });
         }
       });
-      const num = sumProduct - ((sum1 * sum2) / n);
-      const den = Math.sqrt((sum1Sq - ((sum1 * sum1) / n)) * (sum2Sq - ((sum2 * sum2) / n)));
-
-      if (n !== 0 && den !== 0) {
-        validPearsons.push({ username: u, correlation: num / den, group: numVotes < voteMinimum ? GROUP.few : undefined });
-      }
-    });
 
     return validPearsons.sort((a, b) => a.correlation - b.correlation);
   }, [user1, votes, entryPositionLookup, voteMinimum]);
@@ -77,8 +95,10 @@ function PearsonsCorrelation({
     x: i,
     y: p.correlation,
     id: p.username,
-    group: p.username === user2 ? GROUP.selected : (p.group || GROUP.none),
-    text: `User 2: ${trimUsername(p.username)}<br />Pearsons: ${roundTwoDecimals(p.correlation)}`,
+    group: p.username === user2 ? GROUP.selected : p.group || GROUP.none,
+    text: `User 2: ${trimUsername(
+      p.username,
+    )}<br />Pearsons: ${roundTwoDecimals(p.correlation)}`,
   }));
 
   /**
@@ -100,19 +120,22 @@ function PearsonsCorrelation({
    * ALLOW KEYED NAVIGATION OF THIS CHART (up-down arrows)
    */
   const usernames = useMemo(() => pearsons.map((p) => p.username), [pearsons]);
-  const handleKeyDown = useCallback((event) => {
-    const { key } = event;
-    if (key === 'ArrowUp' || key === 'ArrowDown') {
-      event.preventDefault();
-      setUser2((prev) => {
-        const index = usernames.indexOf(prev);
-        if (key === 'ArrowUp') {
-          return usernames[index + 1] || usernames[0];
-        }
-        return usernames[index - 1] || usernames[usernames.length - 1];
-      });
-    }
-  }, [setUser2, usernames]);
+  const handleKeyDown = useCallback(
+    (event) => {
+      const { key } = event;
+      if (key === 'ArrowUp' || key === 'ArrowDown') {
+        event.preventDefault();
+        setUser2((prev) => {
+          const index = usernames.indexOf(prev);
+          if (key === 'ArrowUp') {
+            return usernames[index + 1] || usernames[0];
+          }
+          return usernames[index - 1] || usernames[usernames.length - 1];
+        });
+      }
+    },
+    [setUser2, usernames],
+  );
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);

--- a/react-ui/src/pages/analyzeVotes/UserVsAverage.jsx
+++ b/react-ui/src/pages/analyzeVotes/UserVsAverage.jsx
@@ -1,12 +1,8 @@
-/* eslint-disable max-len */
 /* eslint-disable react/forbid-prop-types */
 import PropTypes, { object } from 'prop-types';
 import Plot from 'react-plotly.js';
 
-import {
-  roundTwoDecimals,
-  createTraces,
-} from './functions';
+import { roundTwoDecimals, createTraces } from './functions';
 import MARKERS from './markers';
 
 const USER_GROUP = { none: 0, submitted: 1 };
@@ -16,16 +12,24 @@ const ENTRY_GROUP = { none: 0, user1: 1 };
  * Display user votes vs the flag average across entire contest
  */
 function UserVsAverage({
-  user1, votes, entryAvg, entryUserLookup, entryPositionLookup,
+  user1,
+  votes,
+  entryAvg,
+  entryUserLookup,
+  entryPositionLookup,
 }) {
   /**
    * CREATE DATA POINTS FOR TRACES
    */
   const userPoints = Array.from({ length: entryAvg.length }, (_, i) => ({
-    x: i, y: undefined, group: USER_GROUP.none,
+    x: i,
+    y: undefined,
+    group: USER_GROUP.none,
   }));
   const entryPoints = Array.from({ length: entryAvg.length }, (_, i) => ({
-    x: i, y: entryAvg[i].average, group: ENTRY_GROUP.none,
+    x: i,
+    y: entryAvg[i].average,
+    group: ENTRY_GROUP.none,
   }));
   const userBarPoints = [];
 
@@ -46,10 +50,15 @@ function UserVsAverage({
       userPoints[i].group = USER_GROUP.submitted;
       entryPoints[i].group = ENTRY_GROUP.user1;
       userBarPoints.push({
-        x: i, y: 5, group: 0, text: 'User 1 entry',
+        x: i,
+        y: 5,
+        group: 0,
+        text: 'User 1 entry',
       });
     }
-    const text = `User score: ${userPoints[i].y ?? 'None'}<br />Flag average: ${roundTwoDecimals(ea.average)}`;
+    const text = `User score: ${
+      userPoints[i].y ?? 'None'
+    }<br />Flag average: ${roundTwoDecimals(ea.average)}`;
     userPoints[i].text = text;
     entryPoints[i].text = text;
   });
@@ -67,9 +76,16 @@ function UserVsAverage({
     { name: 'Average (User 1 entry)', marker: MARKERS.average.submitted },
   ]);
 
-  const userBarTraces = createTraces(userBarPoints, [{ name: 'User 1 entry', marker: MARKERS.bar.user }], { type: 'bar', width: 1 });
+  const userBarTraces = createTraces(
+    userBarPoints,
+    [{ name: 'User 1 entry', marker: MARKERS.bar.user }],
+    { type: 'bar', width: 1 },
+  );
   const data = [...userTraces, ...entryTraces, ...userBarTraces];
-  const userVotes = userPoints.reduce((acc, curr) => (curr.y > -1 ? acc + 1 : acc), 0);
+  const userVotes = userPoints.reduce(
+    (acc, curr) => (curr.y > -1 ? acc + 1 : acc),
+    0,
+  );
 
   const layout = {
     title: `${user1}'s votes compared to average (${userVotes}/${entryAvg.length})`,
@@ -77,13 +93,7 @@ function UserVsAverage({
     yaxis: { title: 'Score', range: [-0.5, 5.5] },
   };
 
-  return (
-    <Plot
-      data={data}
-      layout={layout}
-      showLegend
-    />
-  );
+  return <Plot data={data} layout={layout} showLegend />;
 }
 
 export default UserVsAverage;

--- a/react-ui/src/pages/analyzeVotes/UserVsUser.jsx
+++ b/react-ui/src/pages/analyzeVotes/UserVsUser.jsx
@@ -1,11 +1,8 @@
-/* eslint-disable max-len */
 /* eslint-disable react/forbid-prop-types */
 import PropTypes, { object } from 'prop-types';
 import Plot from 'react-plotly.js';
 
-import {
-  roundTwoDecimals, createTraces,
-} from './functions';
+import { roundTwoDecimals, createTraces } from './functions';
 import MARKERS from './markers';
 
 const USER_GROUP = { none: 0, submitted: 1, shared: 2 };
@@ -15,19 +12,30 @@ const ENTRY_GROUP = { none: 0, user1: 1, user2: 2 };
  * Display user votes vs user2 votes across entire contest
  */
 function UserVsUser({
-  user1, user2, votes, entryAvg, entryUserLookup, entryPositionLookup,
+  user1,
+  user2,
+  votes,
+  entryAvg,
+  entryUserLookup,
+  entryPositionLookup,
 }) {
   /**
    * CREATE DATA POINTS FOR TRACES
    */
   const userPoints = Array.from({ length: entryAvg.length }, (_, i) => ({
-    x: i, y: undefined, group: USER_GROUP.none,
+    x: i,
+    y: undefined,
+    group: USER_GROUP.none,
   }));
   const user2Points = Array.from({ length: entryAvg.length }, (_, i) => ({
-    x: i, y: undefined, group: USER_GROUP.none,
+    x: i,
+    y: undefined,
+    group: USER_GROUP.none,
   }));
   const entryPoints = Array.from({ length: entryAvg.length }, (_, i) => ({
-    x: i, y: entryAvg[i].average, group: ENTRY_GROUP.none,
+    x: i,
+    y: entryAvg[i].average,
+    group: ENTRY_GROUP.none,
   }));
   const userBarPoints = [];
   const user2BarPoints = [];
@@ -36,10 +44,17 @@ function UserVsUser({
    * ADD RATINGS (y-value) TO USER DATA POINTS
    */
   votes.forEach((vote) => {
-    // TEMP FIX. Sometimes throws TypeError (11vfqjf/mar23), even though user2Points and entryPositionLookup are both derived from entryAvg
-    if (vote.username === user1 && userPoints[entryPositionLookup[vote.entryId]]) {
+    // TEMP FIX. Sometimes throws TypeError (11vfqjf/mar23), even though user2Points and
+    // entryPositionLookup are both derived from entryAvg
+    if (
+      vote.username === user1
+      && userPoints[entryPositionLookup[vote.entryId]]
+    ) {
       userPoints[entryPositionLookup[vote.entryId]].y = vote.rating;
-    } else if (vote.username === user2 && user2Points[entryPositionLookup[vote.entryId]]) {
+    } else if (
+      vote.username === user2
+      && user2Points[entryPositionLookup[vote.entryId]]
+    ) {
       user2Points[entryPositionLookup[vote.entryId]].y = vote.rating;
     }
   });
@@ -63,16 +78,24 @@ function UserVsUser({
       userPoints[i].group = USER_GROUP.submitted;
       entryPoints[i].group = ENTRY_GROUP.user1;
       userBarPoints.push({
-        x: i, y: 5, group: 0, text: 'User 1 entry',
+        x: i,
+        y: 5,
+        group: 0,
+        text: 'User 1 entry',
       });
     } else if (entryUserLookup[ea.entryId] === user2) {
       user2Points[i].group = USER_GROUP.submitted;
       entryPoints[i].group = ENTRY_GROUP.user2;
       user2BarPoints.push({
-        x: i, y: 5, group: 0, text: 'User 2 entry',
+        x: i,
+        y: 5,
+        group: 0,
+        text: 'User 2 entry',
       });
     }
-    const text = `User score: ${userPoints[i].y ?? 'None'}<br />User 2 score: ${user2Points[i].y ?? 'None'}<br />Flag average: ${roundTwoDecimals(ea.average)}`;
+    const text = `User score: ${userPoints[i].y ?? 'None'}<br />User 2 score: ${
+      user2Points[i].y ?? 'None'
+    }<br />Flag average: ${roundTwoDecimals(ea.average)}`;
     userPoints[i].text = text;
     user2Points[i].text = text;
     entryPoints[i].text = text;
@@ -99,10 +122,24 @@ function UserVsUser({
   /**
    * CONVERT DATA POINTS TO TRACES
    */
-  const userBarTraces = createTraces(userBarPoints, [{ name: 'User 1 entry', marker: MARKERS.bar.user }], { type: 'bar', width: 1 });
-  const user2BarTraces = createTraces(user2BarPoints, [{ name: 'User 2 entry', marker: MARKERS.bar.user2 }], { type: 'bar', width: 1 });
+  const userBarTraces = createTraces(
+    userBarPoints,
+    [{ name: 'User 1 entry', marker: MARKERS.bar.user }],
+    { type: 'bar', width: 1 },
+  );
+  const user2BarTraces = createTraces(
+    user2BarPoints,
+    [{ name: 'User 2 entry', marker: MARKERS.bar.user2 }],
+    { type: 'bar', width: 1 },
+  );
 
-  const data = [...userTraces, ...user2Traces, ...entryTraces, ...userBarTraces, ...user2BarTraces];
+  const data = [
+    ...userTraces,
+    ...user2Traces,
+    ...entryTraces,
+    ...userBarTraces,
+    ...user2BarTraces,
+  ];
 
   const layout = {
     title: `${user1}'s votes to ${user2}'s`,
@@ -110,13 +147,7 @@ function UserVsUser({
     yaxis: { title: 'Score', range: [-0.5, 5.5] },
   };
 
-  return (
-    <Plot
-      data={data}
-      layout={layout}
-      showLegend
-    />
-  );
+  return <Plot data={data} layout={layout} showLegend />;
 }
 
 export default UserVsUser;

--- a/react-ui/src/pages/hallOfFame/HallOfFame.jsx
+++ b/react-ui/src/pages/hallOfFame/HallOfFame.jsx
@@ -100,17 +100,19 @@ function HallOfFame() {
   const clientWidth = useClientWidth();
 
   const isSmUp = useMediaQuery(theme.breakpoints.up('sm'));
-  // eslint-disable-next-line max-len
-  const imageWidth = Math.min(clientWidth, theme.breakpoints.values.md) - theme.spacing(isSmUp ? 3 : 2) * 2;
+  const imageWidth = Math.min(clientWidth, theme.breakpoints.values.md)
+    - theme.spacing(isSmUp ? 3 : 2) * 2;
 
   const handleTabsChange = (event, newValue) => {
     setSelectedYear(newValue);
     animateScroll.scrollTo(
-      document.getElementById(`hofc-${groups[newValue][0].date}`).getBoundingClientRect().top
-      + window.scrollY
-      - getToolbarHeight()
-      - tabsHeight
-      - theme.spacing(3) / 2,
+      document
+        .getElementById(`hofc-${groups[newValue][0].date}`)
+        .getBoundingClientRect().top
+        + window.scrollY
+        - getToolbarHeight()
+        - tabsHeight
+        - theme.spacing(3) / 2,
       {
         duration: 650,
         delay: 0,
@@ -151,7 +153,11 @@ function HallOfFame() {
           </Paper>
           <PageContainer className={classes.content} maxWidth="md">
             {hallOfFame.map((entry) => (
-              <HallOfFameCard key={entry.entryId} entry={entry} imageDisplayWidth={imageWidth} />
+              <HallOfFameCard
+                key={entry.entryId}
+                entry={entry}
+                imageDisplayWidth={imageWidth}
+              />
             ))}
           </PageContainer>
         </>

--- a/react-ui/src/pages/reviewSubmissions/ReviewSubmissions.jsx
+++ b/react-ui/src/pages/reviewSubmissions/ReviewSubmissions.jsx
@@ -54,13 +54,17 @@ function ReviewSubmissions() {
   useEffect(() => {
     let updatedSubmissions = [...submissions];
 
-    const statusesToDisplay = Object.keys(selectedChips).filter((status) => selectedChips[status]);
+    const statusesToDisplay = Object.keys(selectedChips).filter(
+      (status) => selectedChips[status],
+    );
     if (statusesToDisplay.length) {
       // eslint-disable-next-line max-len
       updatedSubmissions = updatedSubmissions.filter(({ submissionStatus }) => statusesToDisplay.includes(submissionStatus));
     }
 
-    const usersToDisplay = Object.keys(selectedUsers).filter((user) => selectedUsers[user]);
+    const usersToDisplay = Object.keys(selectedUsers).filter(
+      (user) => selectedUsers[user],
+    );
     if (usersToDisplay.length) {
       updatedSubmissions = updatedSubmissions.filter(({ user }) => usersToDisplay.includes(user));
     }
@@ -81,7 +85,10 @@ function ReviewSubmissions() {
   }, [showErrorsOnly]);
 
   const handleChipClick = (chipName) => () => {
-    setSelectedChips({ ...selectedChips, [chipName]: !selectedChips[chipName] });
+    setSelectedChips({
+      ...selectedChips,
+      [chipName]: !selectedChips[chipName],
+    });
   };
 
   const toggleErrorFilters = () => {
@@ -150,7 +157,11 @@ You have more than 2 entries in this month's contest. Can you please let us know
                       </li>
                     ))}
                   </ul>
-                  <Button color="primary" onClick={toggleErrorFilters} variant="contained">
+                  <Button
+                    color="primary"
+                    onClick={toggleErrorFilters}
+                    variant="contained"
+                  >
                     {showErrorsOnly ? 'Reset Filters' : 'Show Errors'}
                   </Button>
                 </Alert>

--- a/server/api/contest.js
+++ b/server/api/contest.js
@@ -44,7 +44,9 @@ const filterRepeatedIds = async (data, idField) => {
 const addContestEntries = async (contestId, entries) => {
   const { filteredData, repeatedIds } = await filterRepeatedIds(entries, 'id');
   if (repeatedIds.length) {
-    logger.warn(`Error adding contest entries. Repeated ids: ${repeatedIds.join(', ')}`);
+    logger.warn(
+      `Error adding contest entries. Repeated ids: ${repeatedIds.join(', ')}`,
+    );
   }
   await db.insert(
     'contest_entries',
@@ -59,13 +61,16 @@ const addContestEntries = async (contestId, entries) => {
 const addEntries = async (entries) => {
   const { filteredData, repeatedIds } = await filterRepeatedIds(entries, 'id');
   if (repeatedIds.length) {
-    logger.warn(`Error adding entries. Repeated ids: ${repeatedIds.join(', ')}`);
+    logger.warn(
+      `Error adding entries. Repeated ids: ${repeatedIds.join(', ')}`,
+    );
   }
   await db.insert('entries', filteredData);
 };
 
-// eslint-disable-next-line max-len
-const findMissingEntries = (contest, imagesData) => contest.entries.filter((entry) => !imagesData.find((image) => image.id === entry.imgurId));
+const findMissingEntries = (contest, imagesData) => contest.entries.filter(
+  (entry) => !imagesData.find((image) => image.id === entry.imgurId),
+);
 
 const getVoteData = async (contestId) => {
   const voteData = await db.select(
@@ -75,7 +80,7 @@ const getVoteData = async (contestId) => {
     [contestId],
   );
   return voteData;
-} 
+};
 
 exports.get = async ({ params: { id }, username }, res) => {
   try {
@@ -190,13 +195,20 @@ exports.get = async ({ params: { id }, username }, res) => {
               '?entry_id',
               'rank',
             ]);
-            await db.update('entries', entriesData, ['?id', 'description', 'name', 'user']);
+            await db.update('entries', entriesData, [
+              '?id',
+              'description',
+              'name',
+              'user',
+            ]);
           }
         }
       }
 
       const getEntryRank = (entryId) => {
-        const contestEntry = contestEntriesData.find((entry) => entry.entry_id === entryId);
+        const contestEntry = contestEntriesData.find(
+          (entry) => entry.entry_id === entryId,
+        );
         if (contestEntry) {
           return contestEntry.rank;
         }
@@ -206,9 +218,10 @@ exports.get = async ({ params: { id }, username }, res) => {
       const allImagesData = [...imagesData];
       let missingEntries = findMissingEntries(contest, allImagesData);
       if (missingEntries.length) {
-        const entriesData = await db.select('SELECT * FROM entries WHERE id = ANY ($1)', [
-          missingEntries.map((entry) => entry.imgurId),
-        ]);
+        const entriesData = await db.select(
+          'SELECT * FROM entries WHERE id = ANY ($1)',
+          [missingEntries.map((entry) => entry.imgurId)],
+        );
         const contestEntries = entriesData.map((entry) => ({
           ...entry,
           rank: getEntryRank(entry.id),
@@ -249,7 +262,9 @@ exports.get = async ({ params: { id }, username }, res) => {
       }
 
       contest.entries = contest.entries.reduce((acc, cur) => {
-        const imageData = allImagesData.find((image) => cur.imgurId === image.id);
+        const imageData = allImagesData.find(
+          (image) => cur.imgurId === image.id,
+        );
         if (imageData) {
           const {
             id: imgurId, height, rank, width, user,
@@ -276,11 +291,13 @@ exports.get = async ({ params: { id }, username }, res) => {
       response = { ...response, ...contest };
 
       try {
-        const updateData = response.entries.map(({ description, imgurId, name: entryName }) => ({
-          description,
-          id: imgurId,
-          name: entryName,
-        }));
+        const updateData = response.entries.map(
+          ({ description, imgurId, name: entryName }) => ({
+            description,
+            id: imgurId,
+            name: entryName,
+          }),
+        );
         db.update('entries', updateData, ['?id', 'description', 'name']);
       } catch (err) {
         logger.error(`Unable to update db: ${err}`);
@@ -311,7 +328,10 @@ exports.get = async ({ params: { id }, username }, res) => {
         [id, submissionStatus],
       );
 
-      const votingNotOpenResponse = { name: response.name, votingWindowOpen: false };
+      const votingNotOpenResponse = {
+        name: response.name,
+        votingWindowOpen: false,
+      };
       if (isFuture(voteStart)) {
         res.send(votingNotOpenResponse);
         return;
@@ -358,14 +378,19 @@ exports.get = async ({ params: { id }, username }, res) => {
     }
 
     if (username) {
-      logger.debug(`Auth tokens present, retrieving votes of ${username} on ${id}`);
+      logger.debug(
+        `Auth tokens present, retrieving votes of ${username} on ${id}`,
+      );
       const votes = await db.select(
         'SELECT entry_id, rating FROM votes WHERE contest_id = $1 AND username = $2',
         [id, username],
       );
       logger.debug(`${username} votes on ${id}: '${JSON.stringify(votes)}'`);
 
-      const entriesObj = keyBy(response.entries, response.entries[0]?.imgurId ? 'imgurId' : 'id');
+      const entriesObj = keyBy(
+        response.entries,
+        response.entries[0]?.imgurId ? 'imgurId' : 'id',
+      );
       votes.forEach(({ entryId, rating }) => {
         if (!entriesObj[entryId]) {
           return;
@@ -395,8 +420,9 @@ exports.get = async ({ params: { id }, username }, res) => {
         return hash;
       };
 
-      response.entries = response.entries.map(({ rank, user, ...entry }) => entry).sort(
-        (a, b) => {
+      response.entries = response.entries
+        .map(({ rank, user, ...entry }) => entry)
+        .sort((a, b) => {
           if (a.rating > -1 && b.rating === undefined) {
             return 1;
           }
@@ -407,8 +433,7 @@ exports.get = async ({ params: { id }, username }, res) => {
             return b.rating - a.rating;
           }
           return getHash(b.id) - getHash(a.id);
-        },
-      );
+        });
     } else if (localVoting) {
       let voteData = await getVoteData(id);
       if (!voteData.length) {
@@ -433,7 +458,9 @@ exports.get = async ({ params: { id }, username }, res) => {
           ...map.get(entryId),
         });
       });
-      response.entries = Array.from(map.values()).sort((a, b) => a.rank - b.rank);
+      response.entries = Array.from(map.values()).sort(
+        (a, b) => a.rank - b.rank,
+      );
     } else {
       const [winners, entries] = partition(
         response.entries,

--- a/server/api/submission.js
+++ b/server/api/submission.js
@@ -48,7 +48,9 @@ exports.get = async ({ username }, res) => {
 
     const { now, ...result } = contest;
     const categories = await getCategories(result.id);
-    const backgroundColors = (await db.select('SELECT * FROM background_colors')).map((obj) => obj.color);
+    const backgroundColors = (
+      await db.select('SELECT * FROM background_colors')
+    ).map((obj) => obj.color);
     const response = { ...result, categories, backgroundColors };
 
     if (username) {
@@ -76,8 +78,16 @@ const isWithinSubmissionWindow = async () => {
 exports.post = async (
   {
     body: {
-      category, contestId, description, height, name, url, width, backgroundColor,
-    }, username,
+      category,
+      contestId,
+      description,
+      height,
+      name,
+      url,
+      width,
+      backgroundColor,
+    },
+    username,
   },
   res,
 ) => {
@@ -102,7 +112,11 @@ exports.post = async (
       }
       res
         .status(400)
-        .send(`Expected ${invalidDimensions.join(' and ')} to be integers between 0 and 3000`);
+        .send(
+          `Expected ${invalidDimensions.join(
+            ' and ',
+          )} to be integers between 0 and 3000`,
+        );
       return;
     }
 
@@ -139,7 +153,9 @@ const VALID_STATUSES = ['pending', 'withdrawn'];
 exports.put = async ({ body: { id, submissionStatus }, username }, res) => {
   try {
     if (!VALID_STATUSES.includes(submissionStatus)) {
-      res.status(400).send(`Status must be one of: ${VALID_STATUSES.join(', ')}`);
+      res
+        .status(400)
+        .send(`Status must be one of: ${VALID_STATUSES.join(', ')}`);
       return;
     }
 
@@ -167,7 +183,11 @@ exports.put = async ({ body: { id, submissionStatus }, username }, res) => {
       [response] = await db.update(
         'entries',
         [{ id, modified_by: null, submission_status: submissionStatus }],
-        ['?id', 'modified_by', { name: 'submission_status', cast: 'submission_status' }],
+        [
+          '?id',
+          'modified_by',
+          { name: 'submission_status', cast: 'submission_status' },
+        ],
         ['id', 'submission_status'],
       );
     }

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,11 @@ const helmet = require('helmet');
 
 const accessToken = require('./api/accessToken');
 const analyzeVotes = require('./api/analyzeVotes');
-const { requireAuthentication, requireModerator, processUser } = require('./api/authentication');
+const {
+  requireAuthentication,
+  requireModerator,
+  processUser,
+} = require('./api/authentication');
 const contest = require('./api/contest');
 const contests = require('./api/contests');
 const dev = require('./api/dev');
@@ -25,7 +29,10 @@ const votes = require('./api/votes');
 const { IS_DEV, BACKEND_PORT } = require('./env');
 const { createLogger } = require('./logger');
 
-const logger = createLogger('INDEX');
+const logger = createLogger('INDEX', {
+  handleExceptions: true,
+  handleRejections: true,
+});
 
 // Multi-process to utilize all CPU cores.
 if (!IS_DEV && cluster.isMaster) {
@@ -37,7 +44,9 @@ if (!IS_DEV && cluster.isMaster) {
   }
 
   cluster.on('exit', (worker, code, signal) => {
-    logger.info(`Node cluster worker ${worker.process.pid} exited: code ${code}, signal ${signal}`);
+    logger.info(
+      `Node cluster worker ${worker.process.pid} exited: code ${code}, signal ${signal}`,
+    );
   });
 } else {
   const app = express();
@@ -51,7 +60,9 @@ if (!IS_DEV && cluster.isMaster) {
       const newDomain = isOldDomain ? 'www.vexillologycontests.com' : hostname;
       const redirectUrl = `https://${newDomain}${url}`;
       res.redirect(301, redirectUrl);
-      logger.info(`Request: ${protocol}://${hostname}${url}, redirecting to ${redirectUrl}`);
+      logger.info(
+        `Request: ${protocol}://${hostname}${url}, redirecting to ${redirectUrl}`,
+      );
       return;
     }
 
@@ -79,7 +90,11 @@ if (!IS_DEV && cluster.isMaster) {
           '*.nocookie.net',
           '*.wikimedia.org',
         ],
-        scriptSrc: [...defaultDirectives['script-src'], '*.google.com', '*.gstatic.com'],
+        scriptSrc: [
+          ...defaultDirectives['script-src'],
+          '*.google.com',
+          '*.gstatic.com',
+        ],
       },
     }),
   );
@@ -101,9 +116,7 @@ if (!IS_DEV && cluster.isMaster) {
     .route('/reviewSubmissions')
     .get(reviewSubmissions.get)
     .put(checkRequiredFields('id', 'status'), reviewSubmissions.put);
-  modRouter
-    .route('/analyzeVotes/:id')
-    .get(analyzeVotes.get);
+  modRouter.route('/analyzeVotes/:id').get(analyzeVotes.get);
 
   const apiRouter = express.Router();
   apiRouter.use(express.json());
@@ -114,7 +127,11 @@ if (!IS_DEV && cluster.isMaster) {
   apiRouter.get('/hallOfFame', hallOfFame.get);
   apiRouter.get('/init', processUser(true), init.get);
   apiRouter.get('/revokeToken/:refreshToken', revokeToken.get);
-  apiRouter.route('/settings').all(requireAuthentication).get(settings.get).put(settings.put);
+  apiRouter
+    .route('/settings')
+    .all(requireAuthentication)
+    .get(settings.get)
+    .put(settings.put);
   apiRouter
     .route('/submission')
     .get(processUser(false), submission.get)
@@ -123,7 +140,11 @@ if (!IS_DEV && cluster.isMaster) {
       checkRequiredFields('description', 'height', 'name', 'url', 'width'),
       submission.post,
     )
-    .put(requireAuthentication, checkRequiredFields('id', 'submissionStatus'), submission.put);
+    .put(
+      requireAuthentication,
+      checkRequiredFields('id', 'submissionStatus'),
+      submission.put,
+    );
   apiRouter
     .route('/votes')
     .all(requireAuthentication, votes.all)
@@ -144,12 +165,16 @@ if (!IS_DEV && cluster.isMaster) {
 
   // All remaining requests return the React app, so it can handle routing.
   app.get('*', (request, response) => {
-    response.sendFile(path.resolve(__dirname, '../react-ui/build', 'index.html'));
+    response.sendFile(
+      path.resolve(__dirname, '../react-ui/build', 'index.html'),
+    );
   });
 
   app.listen(BACKEND_PORT, () => {
     logger.info(
-      `Node ${IS_DEV ? 'dev server' : `cluster worker ${process.pid}`}: listening on port ${BACKEND_PORT}`,
+      `Node ${
+        IS_DEV ? 'dev server' : `cluster worker ${process.pid}`
+      }: listening on port ${BACKEND_PORT}`,
     );
   });
 }

--- a/server/logger.js
+++ b/server/logger.js
@@ -3,18 +3,19 @@
  */
 
 const winston = require('winston');
+
 const { LOG_LEVEL } = require('./env');
 
 const { format } = winston;
 
-const createLogger = (customLabel) => winston.createLogger({
+const createLogger = (
+  label,
+  { handleExceptions = false, handleRejections = false } = {},
+) => winston.loggers.add(label, {
   level: LOG_LEVEL,
-  format: format.combine(
-    format.label({ label: customLabel }),
-    format.json(),
-  ),
+  format: format.combine(format.label({ label }), format.json()),
   transports: [
-    new winston.transports.Console({ handleExceptions: true, handleRejections: true }),
+    new winston.transports.Console({ handleExceptions, handleRejections }),
   ],
   exitOnError: false,
 });


### PR DESCRIPTION
I have been noticing a lot of noise in the server logs recently with a lot of 400 Bad Request errors. I'm pretty sure those are from the snoowrap library (which I just found out has been archived), but I wasn't sure why there were so many of them. I dug a little deeper and found the errors being logged from files that didn't even interact with the library and realized that I each logger was logging unhandled exceptions and rejections, so there were a dozen entries for each error. I refactored the way logs are created, so that only the INDEX one tries logging unhandled exceptions/rejections.

Sorry for the noise in this CL, but I tried setting the line length in the Prettier config to shorter than the ESLint config, and it did a much better job of placing line breaks, so we only need 3 of the `max-len` statements in the app. By running Prettier -> ESLint, it did a lot of reformatting to the files, but the only files I changed the logic in are logger.js and index.js (to pass the new params). You should be able to safely ignore the remaining files.