### PR TITLE
Fix logging and statuses for votes

### DIFF
--- a/server/api/votes.js
+++ b/server/api/votes.js
@@ -38,7 +38,7 @@ exports.all = async ({ body: { contestId } }, res, next) => {
       }
 
       if (isBefore(now, voteStart)) {
-        logger.error('Vote submitted before voting window opened');
+        logger.warn('Vote submitted before voting window opened');
         res.status(400).send(`Voting window doesn't open until ${voteStart}`);
         return;
       }

--- a/server/api/votes.js
+++ b/server/api/votes.js
@@ -24,6 +24,7 @@ exports.all = async ({ body: { contestId } }, res, next) => {
         localVoting, now, voteStart, voteEnd,
       }] = voteDates;
       if (!localVoting) {
+        // Older contest from when voting was done in Reddit
         const message = 'Contest does not allow local voting';
         logger.warn(`${message}: ${contestId}`);
         res.status(400).send(message);

--- a/server/db/queries.js
+++ b/server/db/queries.js
@@ -58,7 +58,7 @@ exports.getCurrentContestSubmissions = async () => {
 
 exports.getVoteDates = async (contestId) => {
   const voteDates = await db.select(
-    'SELECT vote_start, vote_end, now() FROM contests WHERE id = $1',
+    'SELECT local_voting, vote_start, vote_end, now() FROM contests WHERE id = $1',
     [contestId],
   );
   return voteDates;


### PR DESCRIPTION
I got a few errors in the logs saying vote dates couldn't be found for old, reddit-era contests. I looked into the data, and found the following issues:

- The logger was misconfigured, so errors were misattributed to contests rather than votes
- There was no check to see if the contest allowed local voting in the first place
- Some of the error codes didn't really make sense, 403 Forbidden is more for authentication/authorization issues and 500 indicates there is a problem on the server side, when it's really a problem with the request, so it should be 4xx. 400 Bad Request seems to make the most sense for all of these.