### PR TITLE
Delete expired tokens from state

### DIFF
--- a/react-ui/src/components/AccountMenu.jsx
+++ b/react-ui/src/components/AccountMenu.jsx
@@ -71,8 +71,14 @@ function AccountMenu({ color }) {
   const sendUserToAuthUrl = useRedditLogIn();
 
   const {
-    data: { moderator, submissionsToReview },
+    data: { loginExpired, moderator, submissionsToReview },
   } = useSwrInit();
+
+  useEffect(() => {
+    if (loginExpired) {
+      setAuthState({});
+    }
+  }, [loginExpired]);
 
   const toggleMenu = () => {
     setMenuOpen((prevOpen) => !prevOpen);

--- a/server/api/authentication.js
+++ b/server/api/authentication.js
@@ -40,6 +40,7 @@ const processUser = (checkModerator) => async (req, res, next) => {
       req.moderator = moderator;
     }
   } catch (e) {
+    req.username = null;
     logger.warn(`Error retrieving username: ${e}`);
   }
 

--- a/server/api/authentication.js
+++ b/server/api/authentication.js
@@ -40,8 +40,10 @@ const processUser = (checkModerator) => async (req, res, next) => {
       req.moderator = moderator;
     }
   } catch (e) {
-    req.username = null;
     logger.warn(`Error retrieving username: ${e}`);
+    if (e?.statusCode === 400) {
+      req.loginExpired = true;
+    }
   }
 
   next();

--- a/server/api/init.js
+++ b/server/api/init.js
@@ -9,7 +9,12 @@ const { WEB_APP_CLIENT_ID } = process.env;
 
 const logger = createLogger('API/INIT');
 
-exports.get = async ({ moderator, userAttributes, username }, res) => {
+exports.get = async (
+  {
+    loginExpired, moderator, userAttributes, username,
+  },
+  res,
+) => {
   try {
     const experimentsData = await db.select('SELECT * FROM experiments');
     const experiments = experimentsData.reduce((acc, { active, name }) => {
@@ -19,7 +24,7 @@ exports.get = async ({ moderator, userAttributes, username }, res) => {
 
     const response = {
       experiments,
-      loginExpired: username === null,
+      loginExpired,
       title: TITLE,
       webAppClientId: WEB_APP_CLIENT_ID,
     };

--- a/server/api/init.js
+++ b/server/api/init.js
@@ -19,6 +19,7 @@ exports.get = async ({ moderator, userAttributes, username }, res) => {
 
     const response = {
       experiments,
+      loginExpired: username === null,
       title: TITLE,
       webAppClientId: WEB_APP_CLIENT_ID,
     };


### PR DESCRIPTION
There's been a few reports of users being unable to submit flags or vote, and I've seen some 401s in our logs, that look like they're coming from getUser.

I even tried my credentials on staging and they returned an error on getUser, but when I signed out and signed back into staging, the new token worked, so I feel like this should fix the issue for folks who have expired tokens.