### PR TITLE
Update cast for submission_status

### DIFF
--- a/server/api/reviewSubmissions.js
+++ b/server/api/reviewSubmissions.js
@@ -74,7 +74,10 @@ exports.put = async ({ body: { id, rejectionReason, status }, username }, res) =
         '?id',
         'modified_by',
         'rejection_reason',
-        { name: 'submission_status', cast: 'submission_status' },
+        {
+          name: 'submission_status',
+          cast: 'vexillology_contests_common.submission_status',
+        },
       ],
       ['id', 'modified_by', 'rejection_reason', 'submission_status'],
     );


### PR DESCRIPTION
After refactoring the database, the submission_status type was moved to a new vexillology_contests_common schema, so the cast needed to be updated as well