### PR TITLE
Migrate ReCaptcha Key

### DIFF
--- a/react-ui/src/common/firebase.js
+++ b/react-ui/src/common/firebase.js
@@ -23,7 +23,7 @@ const app = initializeApp({
 });
 
 initializeAppCheck(app, {
-  provider: new ReCaptchaV3Provider('6LdVdzMlAAAAACClyDjipqu8966AvQBm_Eb5gNuE'),
+  provider: new ReCaptchaV3Provider('6LeRZR4sAAAAALEsF3zroxaSxq1p9r75oYIWLzSp'),
   isTokenAutoRefreshEnabled: true,
 });
 


### PR DESCRIPTION
I had gotten an email that the ReCaptcha key was going to get automigrated and didn't pay enough attention to it. It created a new Google Cloud project for it, which I would like to delete, so I don't have a whole project just for a key. Turns out I have to recreate the key in the existing vexillology-contests cloud project, so this is the new key.

I'll wait to merge this until after the submission window is over to avoid potentially breaking things now.