### PR TITLE
Refresh contests_summary materialized view on contest certification

### DIFF
--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -25,6 +25,7 @@
           "caseInsensitive": false
         }
       }
-    ]
+    ],
+    "no-void": ["error", {"allowAsStatement": true}]
   }
 }

--- a/server/api/contest/db.js
+++ b/server/api/contest/db.js
@@ -178,12 +178,18 @@ exports.getUserVotes = async (contestId, username) => db.select(
   [contestId, username],
 );
 
-/**
- * Refreshes the contests summary materialized view.
- *
- * @returns {Promise<void>}
- */
-exports.refreshContestsSummaryView = async () => db.none('REFRESH MATERIALIZED VIEW contests_summary');
+exports.refreshContestsSummaryView = async () => {
+  try {
+    await db.none('REFRESH MATERIALIZED VIEW CONCURRENTLY contests_summary');
+  } catch (err) {
+    logger.warn(
+      `CONCURRENTLY refresh failed, falling back to standard refresh. Error: ${
+        err.message || err
+      }`,
+    );
+    await db.none('REFRESH MATERIALIZED VIEW contests_summary');
+  }
+};
 
 /**
  * Updates contest entries in the database.

--- a/server/api/contest/db.js
+++ b/server/api/contest/db.js
@@ -183,7 +183,7 @@ exports.getUserVotes = async (contestId, username) => db.select(
  *
  * @returns {Promise<void>}
  */
-exports.refreshContestsSummaryView = async () => db.any('REFRESH MATERIALIZED VIEW contests_summary');
+exports.refreshContestsSummaryView = async () => db.none('REFRESH MATERIALIZED VIEW contests_summary');
 
 /**
  * Updates contest entries in the database.

--- a/server/api/contest/db.js
+++ b/server/api/contest/db.js
@@ -179,26 +179,6 @@ exports.getUserVotes = async (contestId, username) => db.select(
 );
 
 /**
- * Refreshes the contests summary materialized view.
- * Attempts to perform a concurrent refresh first to avoid locking reads on the view,
- * falling back to a standard refresh if the concurrent attempt fails.
- *
- * @returns {Promise<void>}
- */
-exports.refreshContestsSummaryView = async () => {
-  try {
-    await db.none('REFRESH MATERIALIZED VIEW CONCURRENTLY contests_summary');
-  } catch (err) {
-    logger.warn(
-      `CONCURRENTLY refresh failed, falling back to standard refresh. Error: ${
-        err.message || err
-      }`,
-    );
-    await db.none('REFRESH MATERIALIZED VIEW contests_summary');
-  }
-};
-
-/**
  * Updates contest entries in the database.
  *
  * @param {Array<Object>} contestEntries - The contest entries to update.

--- a/server/api/contest/db.js
+++ b/server/api/contest/db.js
@@ -178,6 +178,13 @@ exports.getUserVotes = async (contestId, username) => db.select(
   [contestId, username],
 );
 
+/**
+ * Refreshes the contests summary materialized view.
+ * Attempts to perform a concurrent refresh first to avoid locking reads on the view,
+ * falling back to a standard refresh if the concurrent attempt fails.
+ *
+ * @returns {Promise<void>}
+ */
 exports.refreshContestsSummaryView = async () => {
   try {
     await db.none('REFRESH MATERIALIZED VIEW CONCURRENTLY contests_summary');

--- a/server/api/contest/index.js
+++ b/server/api/contest/index.js
@@ -9,7 +9,11 @@ const { keyBy } = require('lodash');
 const numeral = require('numeral');
 const { v4: uuidv4 } = require('uuid');
 
-const { getVoteDates, getCategories } = require('../../db/queries');
+const {
+  getVoteDates,
+  getCategories,
+  refreshContestsSummaryView,
+} = require('../../db/queries');
 const { IGNORE_PENDING_DEV } = require('../../env');
 const { createLogger } = require('../../logger');
 
@@ -53,7 +57,7 @@ const addCategoriesToEntries = async (contestId, entries) => {
 const addRanksToEntries = async (contestId, entries) => {
   let voteData = await db.getContestVotes(contestId);
   if (!voteData.length) {
-    await db.refreshContestsSummaryView();
+    await refreshContestsSummaryView();
     voteData = await db.getContestVotes(contestId);
   }
 

--- a/server/api/manageContest.js
+++ b/server/api/manageContest.js
@@ -22,7 +22,20 @@ exports.put = async ({ body: { id, resultsCertified } }, res) => {
       return;
     }
     if (resultsCertified) {
-      await db.any('REFRESH MATERIALIZED VIEW contests_summary');
+      db.any('REFRESH MATERIALIZED VIEW CONCURRENTLY contests_summary')
+        .catch((err) => {
+          logger.warn(
+            `CONCURRENTLY refresh failed, falling back to standard refresh. Error: ${
+              err.message || err
+            }`,
+          );
+          return db.any('REFRESH MATERIALIZED VIEW contests_summary');
+        })
+        .catch((err) => {
+          logger.error(
+            `Error refreshing contests_summary view: ${err.message || err}`,
+          );
+        });
     }
     res.send(response);
   } catch (err) {

--- a/server/api/manageContest.js
+++ b/server/api/manageContest.js
@@ -21,6 +21,9 @@ exports.put = async ({ body: { id, resultsCertified } }, res) => {
       res.status(404).send('Contest with that id not found');
       return;
     }
+    if (resultsCertified) {
+      await db.any('REFRESH MATERIALIZED VIEW contests_summary');
+    }
     res.send(response);
   } catch (err) {
     logger.error(`Error putting /manageContest: ${err}`);

--- a/server/api/manageContest.js
+++ b/server/api/manageContest.js
@@ -1,7 +1,6 @@
 const db = require('../db');
+const { refreshContestsSummaryView } = require('../db/queries');
 const { createLogger } = require('../logger');
-
-const contestDb = require('./contest/db');
 
 const logger = createLogger('API/CONTEST_SUMMARY');
 
@@ -26,7 +25,7 @@ exports.put = async ({ body: { id, resultsCertified } }, res) => {
     if (resultsCertified) {
       // Refresh the materialized view in the background so we don't block the API response.
       // The void operator indicates that this promise is intentionally not awaited.
-      void contestDb.refreshContestsSummaryView().catch((err) => {
+      void refreshContestsSummaryView().catch((err) => {
         logger.error(
           `Error background refreshing contests_summary view: ${
             err.message || err

--- a/server/api/manageContest.js
+++ b/server/api/manageContest.js
@@ -1,6 +1,8 @@
 const db = require('../db');
 const { createLogger } = require('../logger');
 
+const contestDb = require('./contest/db');
+
 const logger = createLogger('API/CONTEST_SUMMARY');
 
 exports.put = async ({ body: { id, resultsCertified } }, res) => {
@@ -24,21 +26,13 @@ exports.put = async ({ body: { id, resultsCertified } }, res) => {
     if (resultsCertified) {
       // Refresh the materialized view in the background so we don't block the API response.
       // The void operator indicates that this promise is intentionally not awaited.
-      void db
-        .none('REFRESH MATERIALIZED VIEW CONCURRENTLY contests_summary')
-        .catch((err) => {
-          logger.warn(
-            `CONCURRENTLY refresh failed, falling back to standard refresh. Error: ${
-              err.message || err
-            }`,
-          );
-          return db.none('REFRESH MATERIALIZED VIEW contests_summary');
-        })
-        .catch((err) => {
-          logger.error(
-            `Error refreshing contests_summary view: ${err.message || err}`,
-          );
-        });
+      void contestDb.refreshContestsSummaryView().catch((err) => {
+        logger.error(
+          `Error background refreshing contests_summary view: ${
+            err.message || err
+          }`,
+        );
+      });
     }
     res.send(response);
   } catch (err) {

--- a/server/api/manageContest.js
+++ b/server/api/manageContest.js
@@ -22,6 +22,8 @@ exports.put = async ({ body: { id, resultsCertified } }, res) => {
       return;
     }
     if (resultsCertified) {
+      // Refresh the materialized view in the background so we don't block the API response.
+      // This promise is intentionally not awaited as it is a non-critical background operation.
       db.any('REFRESH MATERIALIZED VIEW CONCURRENTLY contests_summary')
         .catch((err) => {
           logger.warn(

--- a/server/api/manageContest.js
+++ b/server/api/manageContest.js
@@ -23,8 +23,9 @@ exports.put = async ({ body: { id, resultsCertified } }, res) => {
     }
     if (resultsCertified) {
       // Refresh the materialized view in the background so we don't block the API response.
-      // This promise is intentionally not awaited as it is a non-critical background operation.
-      db.any('REFRESH MATERIALIZED VIEW CONCURRENTLY contests_summary')
+      // The void operator indicates that this promise is intentionally not awaited.
+      void db
+        .any('REFRESH MATERIALIZED VIEW CONCURRENTLY contests_summary')
         .catch((err) => {
           logger.warn(
             `CONCURRENTLY refresh failed, falling back to standard refresh. Error: ${

--- a/server/api/manageContest.js
+++ b/server/api/manageContest.js
@@ -25,14 +25,14 @@ exports.put = async ({ body: { id, resultsCertified } }, res) => {
       // Refresh the materialized view in the background so we don't block the API response.
       // The void operator indicates that this promise is intentionally not awaited.
       void db
-        .any('REFRESH MATERIALIZED VIEW CONCURRENTLY contests_summary')
+        .none('REFRESH MATERIALIZED VIEW CONCURRENTLY contests_summary')
         .catch((err) => {
           logger.warn(
             `CONCURRENTLY refresh failed, falling back to standard refresh. Error: ${
               err.message || err
             }`,
           );
-          return db.any('REFRESH MATERIALIZED VIEW contests_summary');
+          return db.none('REFRESH MATERIALIZED VIEW contests_summary');
         })
         .catch((err) => {
           logger.error(

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -117,4 +117,5 @@ module.exports = {
   select,
   update,
   any: db.any,
+  none: db.none,
 };

--- a/server/db/queries.js
+++ b/server/db/queries.js
@@ -3,11 +3,15 @@
  * @exports getCurrentContest
  * @exports getCurrentContestSubmissions
  * @exports getVoteDates
+ * @exports refreshContestsSummaryView
  */
 
 const { ALLOW_DEV_CONTEST } = require('../env');
+const { createLogger } = require('../logger');
 
 const db = require('.');
+
+const logger = createLogger('DB/QUERIES');
 
 exports.getCategories = async (contestId) => {
   const categories = await db.select(
@@ -71,4 +75,24 @@ exports.getVoteDates = async (contestId) => {
     [contestId],
   );
   return voteDates;
+};
+
+/**
+ * Refreshes the contests summary materialized view.
+ * Attempts to perform a concurrent refresh first to avoid locking reads on the view,
+ * falling back to a standard refresh if the concurrent attempt fails.
+ *
+ * @returns {Promise<void>}
+ */
+exports.refreshContestsSummaryView = async () => {
+  try {
+    await db.none('REFRESH MATERIALIZED VIEW CONCURRENTLY contests_summary');
+  } catch (err) {
+    logger.warn(
+      `CONCURRENTLY refresh failed, falling back to standard refresh. Error: ${
+        err.message || err
+      }`,
+    );
+    await db.none('REFRESH MATERIALIZED VIEW contests_summary');
+  }
 };


### PR DESCRIPTION
Refreshes the contests_summary materialized view when a contest is certified rather than just when the page is first loaded.