### PR TITLE
fix(ci): use pull_request_target for gemini reviews

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -1,7 +1,7 @@
 name: Gemini PR Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Uses pull_request_target instead of pull_request so that fork PRs can run Gemini PR reviews with access to secrets.