### PR TITLE
feat: auto-install Heroku CLI in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "Vexillology Contests",
+  "postCreateCommand": "curl -fsSL https://cli-assets.heroku.com/install.sh | sudo sh"
+}


### PR DESCRIPTION
Adds `.devcontainer/devcontainer.json` to automatically install the Heroku CLI via `postCreateCommand` when creating a GitHub Codespace for this repository.