### PR TITLE
feat: add Procfile for Heroku local web process

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start


### PR DESCRIPTION
Adds `Procfile` with `web: npm start` so `heroku local` / `npm run heroku` can run the local server without missing Procfile errors.